### PR TITLE
test: fix health check tests

### DIFF
--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -132,7 +132,7 @@ func TestService_Check(t *testing.T) {
 				t.Fatalf("failed to execute method call: %v", err)
 			}
 			if g, w := len(got), len(tc.info); g != w {
-				t.Errorf("slice length mismatch:\ngot:\t%#v\nwant:\t%#v", g, w)
+				t.Fatalf("slice length mismatch:\ngot:\t%#v\nwant:\t%#v", g, w)
 			}
 			for i := 0; i < len(tc.info); i++ {
 				assertInfoEqual(t, got[i], tc.info[i])

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -41,7 +41,7 @@ func TestStatus_String(t *testing.T) {
 	}
 }
 
-func TestNew(t *testing.T) {
+func TestService_Check(t *testing.T) {
 	cases := map[string]struct {
 		checks []CheckFunc
 		info   []Info


### PR DESCRIPTION
This PR implements a fix for a health check test. When the number of checks and the outcome do not match, the assertion should fail fast instead of continuing.