### PR TITLE
refactor: drop register pattern on health.Checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 * Support for Go 1.16 ([#13](https://github.com/loozhengyuan/grench/pull/13))
 
+### Changed
+
+* Drop register pattern on the health.Checker interface ([#16](https://github.com/loozhengyuan/grench/pull/16))
+
 ### Fixed
 
 * Set go.mod `go` directive to minimum supported Go version ([#12](https://github.com/loozhengyuan/grench/pull/12))

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -85,6 +85,8 @@ func (s service) Check() ([]Info, error) {
 }
 
 // New returns a new health check service.
-func New() Checker {
-	return &service{}
+func New(checks ...CheckFunc) Checker {
+	return &service{
+		checks: checks,
+	}
 }

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -53,9 +53,6 @@ type CheckFunc func() (Info, error)
 
 // Checker is the interface of a health check service.
 type Checker interface {
-	// Register registers one or more CheckFuncs with the health check service.
-	Register(...CheckFunc)
-
 	// Check executes and returns the outcome of all registered CheckFuncs.
 	Check() ([]Info, error)
 }
@@ -65,12 +62,6 @@ type service struct {
 }
 
 var _ Checker = (*service)(nil)
-
-func (s *service) Register(checks ...CheckFunc) {
-	for _, c := range checks {
-		s.checks = append(s.checks, c)
-	}
-}
 
 func (s service) Check() ([]Info, error) {
 	var output []Info

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -125,8 +125,7 @@ func TestNew(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			chkr := New()
-			chkr.Register(tc.checks...)
+			chkr := New(tc.checks...)
 			got, err := chkr.Check()
 			if err != nil && !errors.Is(err, errFake) {
 				t.Fatalf("failed to execute method call: %v", err)


### PR DESCRIPTION
This PR changes the `health.Checker` interface by dropping the `Register` method.

The old pattern allows the underlying checks to be added after instantiation, which is not ideal since this leaks implementation details of the underlying `health.Checker` and may be potentially undesirable when duplicate checks are erroneously added to the health check service.