### PR TITLE
refactor: disallow checks from returning errors

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -49,12 +49,12 @@ type Info struct {
 }
 
 // CheckFunc is a functional expression of a check procedure.
-type CheckFunc func() (Info, error)
+type CheckFunc func() Info
 
 // Checker is the interface of a health check service.
 type Checker interface {
 	// Check executes and returns the outcome of all registered CheckFuncs.
-	Check() ([]Info, error)
+	Check() []Info
 }
 
 type service struct {
@@ -63,16 +63,12 @@ type service struct {
 
 var _ Checker = (*service)(nil)
 
-func (s service) Check() ([]Info, error) {
+func (s service) Check() []Info {
 	status := make([]Info, 0, len(s.checks))
 	for _, check := range s.checks {
-		info, err := check()
-		if err != nil {
-			return nil, err
-		}
-		status = append(status, info)
+		status = append(status, check())
 	}
-	return status, nil
+	return status
 }
 
 // New returns a new health check service.

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -1,12 +1,9 @@
 package health
 
 import (
-	"errors"
 	"reflect"
 	"testing"
 )
-
-var errFake = errors.New("fake error")
 
 func TestStatus_String(t *testing.T) {
 	cases := map[string]struct {
@@ -48,12 +45,11 @@ func TestService_Check(t *testing.T) {
 	}{
 		"check_single_distinct": {
 			checks: []CheckFunc{
-				func() (Info, error) {
-					info := Info{
+				func() Info {
+					return Info{
 						Component: "db",
 						Status:    StatusPass,
 					}
-					return info, nil
 				},
 			},
 			info: []Info{
@@ -62,26 +58,23 @@ func TestService_Check(t *testing.T) {
 		},
 		"check_multiple_duplicates": {
 			checks: []CheckFunc{
-				func() (Info, error) {
-					info := Info{
+				func() Info {
+					return Info{
 						Component: "db",
 						Status:    StatusPass,
 					}
-					return info, nil
 				},
-				func() (Info, error) {
-					info := Info{
+				func() Info {
+					return Info{
 						Component: "db",
 						Status:    StatusPass,
 					}
-					return info, nil
 				},
-				func() (Info, error) {
-					info := Info{
+				func() Info {
+					return Info{
 						Component: "db",
 						Status:    StatusPass,
 					}
-					return info, nil
 				},
 			},
 			info: []Info{
@@ -92,31 +85,22 @@ func TestService_Check(t *testing.T) {
 		},
 		"check_multiple_distinct": {
 			checks: []CheckFunc{
-				func() (Info, error) {
-					info := Info{
+				func() Info {
+					return Info{
 						Component: "db",
 						Status:    StatusPass,
 					}
-					return info, nil
 				},
-				func() (Info, error) {
-					info := Info{
+				func() Info {
+					return Info{
 						Component: "api",
 						Status:    StatusFail,
 					}
-					return info, nil
 				},
 			},
 			info: []Info{
 				{Component: "db", Status: StatusPass},
 				{Component: "api", Status: StatusFail},
-			},
-		},
-		"check_error": {
-			checks: []CheckFunc{
-				func() (Info, error) {
-					return Info{}, errFake
-				},
 			},
 		},
 		"check_noop": {},
@@ -126,10 +110,7 @@ func TestService_Check(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			chkr := New(tc.checks...)
-			got, err := chkr.Check()
-			if err != nil && !errors.Is(err, errFake) {
-				t.Fatalf("failed to execute method call: %v", err)
-			}
+			got := chkr.Check()
 			if g, w := len(got), len(tc.info); g != w {
 				t.Fatalf("slice length mismatch:\ngot:\t%#v\nwant:\t%#v", g, w)
 			}


### PR DESCRIPTION
This PR changes the `health.CheckFunc` type and `health.Checker` interface to disallow checks from returning errors.

To be clear, this change does not force errors to be ignored. Rather, it forces errors to be handled at the `CheckFunc` level instead of being handled at the `health.Checker` level.

From a health check perspective, it is not helpful having a separate error value because an error occurred during a check should be reflected in `health.Info` anyway. Disallowing errors to be returned also makes it less ambiguous that checks should return a non-passing `health.Info` when an error has occurred.
