### PR TITLE
refactor: rename functions in pointer package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 * Disallow checks from returning errors ([#21](https://github.com/loozhengyuan/grench/pull/21))
+* Rename functions in pointer package ([#25](https://github.com/loozhengyuan/grench/pull/25))
 
 <!-- END Unreleased -->
 

--- a/pkg/pointer/pointer.go
+++ b/pkg/pointer/pointer.go
@@ -1,37 +1,37 @@
 // Package pointer provides pointer helper functions.
 package pointer
 
-// IntPtr returns the pointer of the int input.
-func IntPtr(i int) *int {
+// Int returns the pointer of the int input.
+func Int(i int) *int {
 	return &i
 }
 
-// Int32Ptr returns the pointer of the int32 input.
-func Int32Ptr(i int32) *int32 {
+// Int32 returns the pointer of the int32 input.
+func Int32(i int32) *int32 {
 	return &i
 }
 
-// Int64Ptr returns the pointer of the int64 input.
-func Int64Ptr(i int64) *int64 {
+// Int64 returns the pointer of the int64 input.
+func Int64(i int64) *int64 {
 	return &i
 }
 
-// Float32Ptr returns the pointer of the float32 input.
-func Float32Ptr(f float32) *float32 {
+// Float32 returns the pointer of the float32 input.
+func Float32(f float32) *float32 {
 	return &f
 }
 
-// Float64Ptr returns the pointer of the float64 input.
-func Float64Ptr(f float64) *float64 {
+// Float64 returns the pointer of the float64 input.
+func Float64(f float64) *float64 {
 	return &f
 }
 
-// BoolPtr returns the pointer of the bool input.
-func BoolPtr(b bool) *bool {
+// Bool returns the pointer of the bool input.
+func Bool(b bool) *bool {
 	return &b
 }
 
-// StringPtr returns the pointer of the string input.
-func StringPtr(s string) *string {
+// String returns the pointer of the string input.
+func String(s string) *string {
 	return &s
 }

--- a/pkg/pointer/pointer_test.go
+++ b/pkg/pointer/pointer_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestIntPtr(t *testing.T) {
+func TestInt(t *testing.T) {
 	cases := map[string]struct {
 		input int
 	}{
@@ -15,7 +15,7 @@ func TestIntPtr(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got := *IntPtr(tc.input) // deference from output
+			got := *Int(tc.input) // deference from output
 			if got != tc.input {
 				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
 			}
@@ -23,7 +23,7 @@ func TestIntPtr(t *testing.T) {
 	}
 }
 
-func TestInt32Ptr(t *testing.T) {
+func TestInt32(t *testing.T) {
 	cases := map[string]struct {
 		input int32
 	}{
@@ -34,7 +34,7 @@ func TestInt32Ptr(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got := *Int32Ptr(tc.input) // deference from output
+			got := *Int32(tc.input) // deference from output
 			if got != tc.input {
 				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
 			}
@@ -42,7 +42,7 @@ func TestInt32Ptr(t *testing.T) {
 	}
 }
 
-func TestInt64Ptr(t *testing.T) {
+func TestInt64(t *testing.T) {
 	cases := map[string]struct {
 		input int64
 	}{
@@ -53,7 +53,7 @@ func TestInt64Ptr(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got := *Int64Ptr(tc.input) // deference from output
+			got := *Int64(tc.input) // deference from output
 			if got != tc.input {
 				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
 			}
@@ -61,7 +61,7 @@ func TestInt64Ptr(t *testing.T) {
 	}
 }
 
-func TestFloat32Ptr(t *testing.T) {
+func TestFloat32(t *testing.T) {
 	cases := map[string]struct {
 		input float32
 	}{
@@ -72,7 +72,7 @@ func TestFloat32Ptr(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got := *Float32Ptr(tc.input) // deference from output
+			got := *Float32(tc.input) // deference from output
 			if got != tc.input {
 				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
 			}
@@ -80,7 +80,7 @@ func TestFloat32Ptr(t *testing.T) {
 	}
 }
 
-func TestFloat64Ptr(t *testing.T) {
+func TestFloat64(t *testing.T) {
 	cases := map[string]struct {
 		input float64
 	}{
@@ -91,7 +91,7 @@ func TestFloat64Ptr(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got := *Float64Ptr(tc.input) // deference from output
+			got := *Float64(tc.input) // deference from output
 			if got != tc.input {
 				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
 			}
@@ -99,7 +99,7 @@ func TestFloat64Ptr(t *testing.T) {
 	}
 }
 
-func TestBoolPtr(t *testing.T) {
+func TestBool(t *testing.T) {
 	cases := map[string]struct {
 		input bool
 	}{
@@ -110,7 +110,7 @@ func TestBoolPtr(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got := *BoolPtr(tc.input) // deference from output
+			got := *Bool(tc.input) // deference from output
 			if got != tc.input {
 				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
 			}
@@ -118,7 +118,7 @@ func TestBoolPtr(t *testing.T) {
 	}
 }
 
-func TestStringPtr(t *testing.T) {
+func TestString(t *testing.T) {
 	cases := map[string]struct {
 		input string
 	}{
@@ -129,7 +129,7 @@ func TestStringPtr(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got := *StringPtr(tc.input) // deference from output
+			got := *String(tc.input) // deference from output
 			if got != tc.input {
 				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
 			}


### PR DESCRIPTION
This PR changes the function names in the pointer package so they sound
better when called.

**Before**
```go
package main

import (
	"github.com/loozhengyuan/grench/pkg/pointer"
)

func main() {
	p := pointer.StringPtr("abc")
}
```

**After**
```go
package main

import (
	"github.com/loozhengyuan/grench/pkg/pointer"
)

func main() {
	p := pointer.String("abc")
}
```