### PR TITLE
chore: move link ref into relevant sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 * New `auth/oidc` package ([#28])
 
+[#28]: https://github.com/loozhengyuan/grench/pull/28
+
 <!-- END Unreleased -->
 
 ## [v0.3.0] - 2021-03-05
@@ -21,10 +23,16 @@ All notable changes to this project will be documented in this file.
 * Health checks now run asynchronously ([#22])
 * JSON struct tags for health.Info ([#24])
 
+[#22]: https://github.com/loozhengyuan/grench/pull/22
+[#24]: https://github.com/loozhengyuan/grench/pull/24
+
 ### Changed
 
 * Disallow checks from returning errors ([#21])
 * Rename functions in pointer package ([#25])
+
+[#21]: https://github.com/loozhengyuan/grench/pull/21
+[#25]: https://github.com/loozhengyuan/grench/pull/25
 
 <!-- END v0.3.0 -->
 
@@ -36,13 +44,19 @@ All notable changes to this project will be documented in this file.
 
 * Support for Go 1.16 ([#13])
 
+[#13]: https://github.com/loozhengyuan/grench/pull/13
+
 ### Changed
 
 * Drop register pattern on the health.Checker interface ([#16])
 
+[#16]: https://github.com/loozhengyuan/grench/pull/16
+
 ### Fixed
 
 * Set go.mod `go` directive to minimum supported Go version ([#12])
+
+[#12]: https://github.com/loozhengyuan/grench/pull/12
 
 <!-- END v0.2.0 -->
 
@@ -53,15 +67,6 @@ All notable changes to this project will be documented in this file.
 Initial release.
 
 <!-- END v0.1.0 -->
-
-[#12]: https://github.com/loozhengyuan/grench/pull/12
-[#13]: https://github.com/loozhengyuan/grench/pull/13
-[#16]: https://github.com/loozhengyuan/grench/pull/16
-[#21]: https://github.com/loozhengyuan/grench/pull/21
-[#22]: https://github.com/loozhengyuan/grench/pull/22
-[#24]: https://github.com/loozhengyuan/grench/pull/24
-[#25]: https://github.com/loozhengyuan/grench/pull/25
-[#28]: https://github.com/loozhengyuan/grench/pull/28
 
 [Unreleased]: https://github.com/loozhengyuan/grench/compare/v0.3.0...HEAD
 [v0.3.0]: https://github.com/loozhengyuan/grench/releases/tag/v0.3.0


### PR DESCRIPTION
The formatting changes introduced in #29 will result in broken links when the relevant sections are pruned for generating release notes. To avoid this, the links and references must be within the same section to ensure portability.