### PR TITLE
feat(utils): add utility func with generics

### DIFF
--- a/utils/coalesce.go
+++ b/utils/coalesce.go
@@ -1,0 +1,20 @@
+package utils
+
+// Coalesce returns the first non-zero value from the input.
+func Coalesce[T comparable](input ...T) T {
+	var x T
+	fn := func(v T) bool {
+		return v != x
+	}
+	return CoalesceFunc(fn, input...)
+}
+
+// CoalesceFunc returns the first non-zero value from the input.
+func CoalesceFunc[T any](fn func(v T) bool, input ...T) T {
+	for _, v := range input {
+		if fn(v) {
+			return v
+		}
+	}
+	return *new(T)
+}

--- a/utils/coalesce/coalesce.go
+++ b/utils/coalesce/coalesce.go
@@ -1,79 +1,44 @@
 // Package coalesce provides coalesce helper functions.
+//
+// Deprecated: Use the [utils.Coalesce] function instead.
 package coalesce
+
+import (
+	"github.com/loozhengyuan/grench/utils"
+)
 
 // Int returns the first non-zero value from the int input.
 func Int(i ...int) int {
-	var x int
-	for _, v := range i {
-		if v != x {
-			return v
-		}
-	}
-	return x
+	return utils.Coalesce(i...)
 }
 
 // Int32 returns the first non-zero value from the int32 input.
 func Int32(i ...int32) int32 {
-	var x int32
-	for _, v := range i {
-		if v != x {
-			return v
-		}
-	}
-	return x
+	return utils.Coalesce(i...)
 }
 
 // Int64 returns the first non-zero value from the int64 input.
 func Int64(i ...int64) int64 {
-	var x int64
-	for _, v := range i {
-		if v != x {
-			return v
-		}
-	}
-	return x
+	return utils.Coalesce(i...)
 }
 
 // Float32 returns the first non-zero value from the float32 input.
 func Float32(f ...float32) float32 {
-	var x float32
-	for _, v := range f {
-		if v != x {
-			return v
-		}
-	}
-	return x
+	return utils.Coalesce(f...)
 }
 
 // Float64 returns the first non-zero value from the float64 input.
 func Float64(f ...float64) float64 {
-	var x float64
-	for _, v := range f {
-		if v != x {
-			return v
-		}
-	}
-	return x
+	return utils.Coalesce(f...)
 }
 
 // String returns the first non-empty value from the string input.
 func String(s ...string) string {
-	var x string
-	for _, v := range s {
-		if v != x {
-			return v
-		}
-	}
-	return x
+	return utils.Coalesce(s...)
 }
 
 // Interface returns the first non-nil value from the interface{} input.
 func Interface(i ...interface{}) interface{} {
 	var x interface{}
-	for _, v := range i {
-		if v != x {
-			return v
-		}
-	}
-	return x
+	return utils.CoalesceFunc(func(v interface{}) bool { return v != x }, i...)
 }

--- a/utils/coalesce_test.go
+++ b/utils/coalesce_test.go
@@ -1,0 +1,392 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestCoalesce_Int(t *testing.T) {
+	cases := map[string]struct {
+		input []int
+		want  int
+	}{
+		"default": {
+			input: []int{0, 0, 0},
+			want:  0, // default null value
+		},
+		"match_first": {
+			input: []int{1, 2, 3},
+			want:  1,
+		},
+		"match_middle": {
+			input: []int{0, 2, 3},
+			want:  2,
+		},
+		"match_last": {
+			input: []int{0, 0, 3},
+			want:  3,
+		},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := Coalesce(tc.input...)
+			if got != tc.want {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func BenchmarkCoalesce_Int(b *testing.B) {
+	benchmarks := map[string]struct {
+		input []int
+	}{
+		"best": {
+			input: []int{1, 0, 0},
+		},
+		"worst": {
+			input: []int{0, 0, 0},
+		},
+	}
+	for name, bm := range benchmarks {
+		bm := bm // capture range variable
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Coalesce(bm.input...)
+			}
+		})
+	}
+}
+
+func TestCoalesce_Int32(t *testing.T) {
+	cases := map[string]struct {
+		input []int32
+		want  int32
+	}{
+		"default": {
+			input: []int32{0, 0, 0},
+			want:  0, // default null value
+		},
+		"match_first": {
+			input: []int32{1, 2, 3},
+			want:  1,
+		},
+		"match_middle": {
+			input: []int32{0, 2, 3},
+			want:  2,
+		},
+		"match_last": {
+			input: []int32{0, 0, 3},
+			want:  3,
+		},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := Coalesce(tc.input...)
+			if got != tc.want {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func BenchmarkCoalesce_Int32(b *testing.B) {
+	benchmarks := map[string]struct {
+		input []int32
+	}{
+		"best": {
+			input: []int32{1, 0, 0},
+		},
+		"worst": {
+			input: []int32{0, 0, 0},
+		},
+	}
+	for name, bm := range benchmarks {
+		bm := bm // capture range variable
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Coalesce(bm.input...)
+			}
+		})
+	}
+}
+
+func TestCoalesce_Int64(t *testing.T) {
+	cases := map[string]struct {
+		input []int64
+		want  int64
+	}{
+		"default": {
+			input: []int64{0, 0, 0},
+			want:  0, // default null value
+		},
+		"match_first": {
+			input: []int64{1, 2, 3},
+			want:  1,
+		},
+		"match_middle": {
+			input: []int64{0, 2, 3},
+			want:  2,
+		},
+		"match_last": {
+			input: []int64{0, 0, 3},
+			want:  3,
+		},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := Coalesce(tc.input...)
+			if got != tc.want {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func BenchmarkCoalesce_Int64(b *testing.B) {
+	benchmarks := map[string]struct {
+		input []int64
+	}{
+		"best": {
+			input: []int64{1, 0, 0},
+		},
+		"worst": {
+			input: []int64{0, 0, 0},
+		},
+	}
+	for name, bm := range benchmarks {
+		bm := bm // capture range variable
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Coalesce(bm.input...)
+			}
+		})
+	}
+}
+
+func TestCoalesce_Float32(t *testing.T) {
+	cases := map[string]struct {
+		input []float32
+		want  float32
+	}{
+		"default": {
+			input: []float32{0, 0, 0},
+			want:  0, // default null value
+		},
+		"match_first": {
+			input: []float32{1, 2, 3},
+			want:  1,
+		},
+		"match_middle": {
+			input: []float32{0, 2, 3},
+			want:  2,
+		},
+		"match_last": {
+			input: []float32{0, 0, 3},
+			want:  3,
+		},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := Coalesce(tc.input...)
+			if got != tc.want {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func BenchmarkCoalesce_Float32(b *testing.B) {
+	benchmarks := map[string]struct {
+		input []float32
+	}{
+		"best": {
+			input: []float32{1, 0, 0},
+		},
+		"worst": {
+			input: []float32{0, 0, 0},
+		},
+	}
+	for name, bm := range benchmarks {
+		bm := bm // capture range variable
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Coalesce(bm.input...)
+			}
+		})
+	}
+}
+
+func TestCoalesce_Float64(t *testing.T) {
+	cases := map[string]struct {
+		input []float64
+		want  float64
+	}{
+		"default": {
+			input: []float64{0, 0, 0},
+			want:  0, // default null value
+		},
+		"match_first": {
+			input: []float64{1, 2, 3},
+			want:  1,
+		},
+		"match_middle": {
+			input: []float64{0, 2, 3},
+			want:  2,
+		},
+		"match_last": {
+			input: []float64{0, 0, 3},
+			want:  3,
+		},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := Coalesce(tc.input...)
+			if got != tc.want {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func BenchmarkCoalesce_Float64(b *testing.B) {
+	benchmarks := map[string]struct {
+		input []float64
+	}{
+		"best": {
+			input: []float64{1, 0, 0},
+		},
+		"worst": {
+			input: []float64{0, 0, 0},
+		},
+	}
+	for name, bm := range benchmarks {
+		bm := bm // capture range variable
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Coalesce(bm.input...)
+			}
+		})
+	}
+}
+
+func TestCoalesce_String(t *testing.T) {
+	cases := map[string]struct {
+		input []string
+		want  string
+	}{
+		"default": {
+			input: []string{"", "", ""},
+			want:  "", // default null value
+		},
+		"match_first": {
+			input: []string{"1", "2", "3"},
+			want:  "1",
+		},
+		"match_middle": {
+			input: []string{"", "2", "3"},
+			want:  "2",
+		},
+		"match_last": {
+			input: []string{"", "", "3"},
+			want:  "3",
+		},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := Coalesce(tc.input...)
+			if got != tc.want {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func BenchmarkCoalesce_String(b *testing.B) {
+	benchmarks := map[string]struct {
+		input []string
+	}{
+		"best": {
+			input: []string{"1", "", ""},
+		},
+		"worst": {
+			input: []string{"", "", ""},
+		},
+	}
+	for name, bm := range benchmarks {
+		bm := bm // capture range variable
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Coalesce(bm.input...)
+			}
+		})
+	}
+}
+
+// TODO: `interface{}` can only satisfy comparable in Go 1.20
+// func TestCoalesce_Interface(t *testing.T) {
+// 	cases := map[string]struct {
+// 		input []interface{}
+// 		want  interface{}
+// 	}{
+// 		"default": {
+// 			input: []interface{}{nil, nil, nil},
+// 			want:  nil, // default null value
+// 		},
+// 		"match_first": {
+// 			input: []interface{}{1, "2", true},
+// 			want:  1,
+// 		},
+// 		"match_middle": {
+// 			input: []interface{}{nil, "2", true},
+// 			want:  "2",
+// 		},
+// 		"match_last": {
+// 			input: []interface{}{nil, nil, true},
+// 			want:  true,
+// 		},
+// 	}
+// 	for name, tc := range cases {
+// 		tc := tc // capture range variable
+// 		t.Run(name, func(t *testing.T) {
+// 			t.Parallel()
+// 			got := Coalesce(tc.input...)
+// 			if got != tc.want {
+// 				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+// 			}
+// 		})
+// 	}
+// }
+
+// TODO: `interface{}` can only satisfy comparable in Go 1.20
+// func BenchmarkCoalesce_Interface(b *testing.B) {
+// 	benchmarks := map[string]struct {
+// 		input []interface{}
+// 	}{
+// 		"best": {
+// 			input: []interface{}{1, nil, nil},
+// 		},
+// 		"worst": {
+// 			input: []interface{}{nil, nil, nil},
+// 		},
+// 	}
+// 	for name, bm := range benchmarks {
+// 		bm := bm // capture range variable
+// 		b.Run(name, func(b *testing.B) {
+// 			for i := 0; i < b.N; i++ {
+// 				Coalesce(bm.input...)
+// 			}
+// 		})
+// 	}
+// }

--- a/utils/pointer.go
+++ b/utils/pointer.go
@@ -1,0 +1,6 @@
+package utils
+
+// Pointer returns the pointer of the input.
+func Pointer[T any](v T) *T {
+	return &v
+}

--- a/utils/pointer/pointer.go
+++ b/utils/pointer/pointer.go
@@ -1,37 +1,43 @@
 // Package pointer provides pointer helper functions.
+//
+// Deprecated: Use the [utils.Coalesce] function instead.
 package pointer
+
+import (
+	"github.com/loozhengyuan/grench/utils"
+)
 
 // Int returns the pointer of the int input.
 func Int(i int) *int {
-	return &i
+	return utils.Pointer(i)
 }
 
 // Int32 returns the pointer of the int32 input.
 func Int32(i int32) *int32 {
-	return &i
+	return utils.Pointer(i)
 }
 
 // Int64 returns the pointer of the int64 input.
 func Int64(i int64) *int64 {
-	return &i
+	return utils.Pointer(i)
 }
 
 // Float32 returns the pointer of the float32 input.
 func Float32(f float32) *float32 {
-	return &f
+	return utils.Pointer(f)
 }
 
 // Float64 returns the pointer of the float64 input.
 func Float64(f float64) *float64 {
-	return &f
+	return utils.Pointer(f)
 }
 
 // Bool returns the pointer of the bool input.
 func Bool(b bool) *bool {
-	return &b
+	return utils.Pointer(b)
 }
 
 // String returns the pointer of the string input.
 func String(s string) *string {
-	return &s
+	return utils.Pointer(s)
 }

--- a/utils/pointer_test.go
+++ b/utils/pointer_test.go
@@ -1,0 +1,138 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestPointer_Int(t *testing.T) {
+	cases := map[string]struct {
+		input int
+	}{
+		"default_value":     {},
+		"non_default_value": {input: 1},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := *Pointer(tc.input) // deference from output
+			if got != tc.input {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func TestPointer_Int32(t *testing.T) {
+	cases := map[string]struct {
+		input int32
+	}{
+		"default_value":     {},
+		"non_default_value": {input: 1},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := *Pointer(tc.input) // deference from output
+			if got != tc.input {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func TestPointer_Int64(t *testing.T) {
+	cases := map[string]struct {
+		input int64
+	}{
+		"default_value":     {},
+		"non_default_value": {input: 1},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := *Pointer(tc.input) // deference from output
+			if got != tc.input {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func TestPointer_Float32(t *testing.T) {
+	cases := map[string]struct {
+		input float32
+	}{
+		"default_value":     {},
+		"non_default_value": {input: 1},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := *Pointer(tc.input) // deference from output
+			if got != tc.input {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func TestPointer_Float64(t *testing.T) {
+	cases := map[string]struct {
+		input float64
+	}{
+		"default_value":     {},
+		"non_default_value": {input: 1},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := *Pointer(tc.input) // deference from output
+			if got != tc.input {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func TestPointer_Bool(t *testing.T) {
+	cases := map[string]struct {
+		input bool
+	}{
+		"default_value":     {},
+		"non_default_value": {input: true},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := *Pointer(tc.input) // deference from output
+			if got != tc.input {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}
+
+func TestPointer_String(t *testing.T) {
+	cases := map[string]struct {
+		input string
+	}{
+		"default_value":     {},
+		"non_default_value": {input: "abc"},
+	}
+	for name, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := *Pointer(tc.input) // deference from output
+			if got != tc.input {
+				t.Errorf("value mismatch:\ngot:\t%#v\nwant:\t%#v", got, tc.input)
+			}
+		})
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,2 @@
+// Package utils provide simple utility functions.
+package utils


### PR DESCRIPTION
Traditionally, the `pointer` and `coalesce` packages are created to deal with Go without generics. With support for generics from Go 1.18, it is possible to have a `Pointer` and `Coalesce` function that covers these 2 packages.

The existing `pointer` and `coalesce` packages will remain but marked as deprecated.